### PR TITLE
Fix newlines in tests on Windows

### DIFF
--- a/src/__tests__/compile.test.ts
+++ b/src/__tests__/compile.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from 'vitest';
+import { EOL } from 'os';
 import { transform } from 'vue-metamorph';
 import { scriptshifter } from '../compile';
 
@@ -17,7 +18,7 @@ it.each([
 
   const result = transform(source, `file.${fileType}`, [scriptshifter]);
 
-  expect(result.code).toBe(source);
+  expect(normalizeLinebreaks(result.code)).toBe(source);
 });
 
 it('should do nothing if the component is already a <script setup> component', () => {
@@ -32,5 +33,9 @@ const count = 2;
 
   const result = transform(source, 'file.vue', [scriptshifter]);
 
-  expect(result.code).toBe(source);
+  expect(normalizeLinebreaks(result.code)).toBe(source);
 });
+
+export function normalizeLinebreaks(code: string) {
+  return EOL === '\n' ? code : code.replaceAll(EOL, '\n');
+}

--- a/src/__tests__/fixtures.test.ts
+++ b/src/__tests__/fixtures.test.ts
@@ -8,6 +8,7 @@ import {
 import { transform } from 'vue-metamorph';
 import { scriptshifter } from '../compile';
 import { vueVersions } from '../options';
+import { normalizeLinebreaks } from './compile.test';
 
 const fixtures = fs
   .readdirSync(path.resolve(__dirname, 'fixtures'))
@@ -18,7 +19,7 @@ describe.each(vueVersions)('Vue %s mode', (mode) => {
   it.each(fixtures)('snapshot %s', async (filename) => {
     const code = fs.readFileSync(path.resolve(__dirname, filename), { encoding: 'utf-8' });
     await expect(
-      transform(code, filename, [scriptshifter], { vue: mode }).code,
+      normalizeLinebreaks(transform(code, filename, [scriptshifter], { vue: mode }).code),
     ).toMatchFileSnapshot(path.resolve(__dirname, filename.replace('.input.vue', `.output.${mode}.vue`)));
   });
 });

--- a/src/__tests__/fixtures/.gitattributes
+++ b/src/__tests__/fixtures/.gitattributes
@@ -1,0 +1,1 @@
+*.vue eol=lf


### PR DESCRIPTION
For the tests to work on Windows, we check out the fixtures with 'lf' newlines even on Windows.

To compare to the transformed test results we make these also use 'lf' newlines consistently. On Windows transformation otherwise returns a mixture of newlines ('lf' and 'crlf').